### PR TITLE
Fix repeated frameworkReady call

### DIFF
--- a/hooks/useFrameworkReady.ts
+++ b/hooks/useFrameworkReady.ts
@@ -9,5 +9,5 @@ declare global {
 export function useFrameworkReady() {
   useEffect(() => {
     window.frameworkReady?.();
-  });
+  }, []);
 }


### PR DESCRIPTION
## Summary
- avoid repeated call to `frameworkReady`

## Testing
- `npm run lint` *(fails: expo not found)*
- `npx tsc -p tsconfig.json` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_b_684314f69c008323bf3bc41073b4dfe2