### PR TITLE
Ensure framework ready only fires on mount

### DIFF
--- a/hooks/useFrameworkReady.ts
+++ b/hooks/useFrameworkReady.ts
@@ -9,5 +9,5 @@ declare global {
 export function useFrameworkReady() {
   useEffect(() => {
     window.frameworkReady?.();
-  });
+  }, []);
 }


### PR DESCRIPTION
## Summary
- update `useFrameworkReady` to only call `frameworkReady` on component mount

## Testing
- `npm run lint` *(fails: `expo` not found)*
- `npx tsc -p tsconfig.json --noEmit` *(fails: cannot find module 'react' and other deps)*

------
https://chatgpt.com/codex/tasks/task_b_6843236a59688323a7f6f2ba91bf34f4