### PR TITLE
Add Jest setup and tests for useEntries hook

### DIFF
--- a/hooks/__tests__/useEntries.test.ts
+++ b/hooks/__tests__/useEntries.test.ts
@@ -1,0 +1,50 @@
+import { renderHook, act } from '@testing-library/react-native';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { useEntries } from '../useEntries';
+
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  getItem: jest.fn(),
+  setItem: jest.fn(),
+}));
+
+describe('useEntries', () => {
+  beforeEach(() => {
+    (AsyncStorage.getItem as jest.Mock).mockReset();
+    (AsyncStorage.setItem as jest.Mock).mockReset();
+  });
+
+  it('saves entries and retrieves them by date', async () => {
+    const storedEntries = [
+      {
+        date: '2024-01-01',
+        entries: ['a', 'b', 'c', 'd', 'e'],
+      },
+    ];
+
+    (AsyncStorage.getItem as jest.Mock)
+      .mockResolvedValueOnce(null) // initial load in saveEntries
+      .mockResolvedValueOnce(JSON.stringify(storedEntries)); // load in getEntriesByDate
+
+    const { result } = renderHook(() => useEntries());
+
+    await act(async () => {
+      const success = await result.current.saveEntries(
+        ['a', 'b', 'c', 'd', 'e'],
+        '2024-01-01',
+      );
+      expect(success).toBe(true);
+    });
+
+    expect(AsyncStorage.setItem).toHaveBeenCalledWith(
+      'daily_five_entries',
+      JSON.stringify(storedEntries),
+    );
+
+    let retrieved: string[] | null = null;
+    await act(async () => {
+      retrieved = await result.current.getEntriesByDate('2024-01-01');
+    });
+
+    expect(retrieved).toEqual(['a', 'b', 'c', 'd', 'e']);
+  });
+});

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "EXPO_NO_TELEMETRY=1 expo start",
     "build:web": "expo export --platform web",
-    "lint": "expo lint"
+    "lint": "expo lint",
+    "test": "jest"
   },
   "dependencies": {
     "@expo-google-fonts/inter": "^0.2.3",
@@ -48,6 +49,8 @@
   "devDependencies": {
     "@babel/core": "^7.25.2",
     "@types/react": "~19.0.10",
-    "typescript": "~5.8.3"
+    "typescript": "~5.8.3",
+    "@testing-library/react-native": "^12.1.5",
+    "jest": "^29.7.0"
   }
 }


### PR DESCRIPTION
## Summary
- add test script and dev dependencies for Jest
- create initial tests for `useEntries` hook

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_68432373ac1c83239040213731f65359